### PR TITLE
Set default HasMany relation to empty array when not persisted.

### DIFF
--- a/src/Relation/HasMany.php
+++ b/src/Relation/HasMany.php
@@ -48,7 +48,7 @@ final class HasMany extends AbstractRelation
     {
         $query = $this->getQuery();
         if ($this->empty) {
-            return null;
+            return [];
         }
 
         return $query->execute();

--- a/tests/Relation/HasManyTest.php
+++ b/tests/Relation/HasManyTest.php
@@ -66,7 +66,7 @@ class HasManyTest extends MockeryTestCase
 
         $relation = new HasMany($person, 'id', Garage::class, 'person_id');
 
-        $this->assertNull($relation->getResults());
+        $this->assertEquals([], $relation->getResults());
     }
 
     public function testSave()


### PR DESCRIPTION
**Description:**
- Updated HasMany::getResults() to return empty array instead of null when empty.

**Reason:**
- Objects that aren't persisted should be able to expect the relation is set/array type w/out having to set it manually.