### PR TITLE
Support join types

### DIFF
--- a/src/Driver/AbstractDriver.php
+++ b/src/Driver/AbstractDriver.php
@@ -128,13 +128,13 @@ abstract class AbstractDriver implements DriverInterface
     protected function addJoins(Query $query, $tablename, $dbQuery)
     {
         foreach ($query->getJoins() as $join) {
-            [$foreignModelClass, $column, $foreignKey] = $join;
+            [$foreignModelClass, $column, $foreignKey, $type] = $join;
 
             $foreignModel = new $foreignModelClass();
             $foreignTablename = $foreignModel->getTablename();
             $condition = $this->prefixColumn($column, $tablename).'='.$this->prefixColumn($foreignKey, $foreignTablename);
 
-            $dbQuery->join($foreignTablename, $condition);
+            $dbQuery->join($foreignTablename, $condition, null, $type);
         }
     }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -222,9 +222,9 @@ class Query
      *
      * @return $this
      */
-    public function join($model, string $column, string $foreignKey)
+    public function join($model, string $column, string $foreignKey, string $type = 'JOIN')
     {
-        $this->joins[] = [$model, $column, $foreignKey];
+        $this->joins[] = [$model, $column, $foreignKey, $type];
 
         return $this;
     }

--- a/tests/Driver/DatabaseDriverTest.php
+++ b/tests/Driver/DatabaseDriverTest.php
@@ -504,7 +504,7 @@ class DatabaseDriverTest extends MockeryTestCase
         $all->shouldReceive('all')
             ->andReturn([['test' => true]]);
         $all->shouldReceive('join')
-            ->withArgs(['Groups', 'People.group=Groups.id'])
+            ->withArgs(['Groups', 'People.group=Groups.id', null, 'JOIN'])
             ->andReturn($db)
             ->once();
         $orderBy = Mockery::mock();

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -119,7 +119,7 @@ class QueryTest extends MockeryTestCase
         $this->assertEquals([], $query->getJoins());
 
         $this->assertEquals($query, $query->join('Person', 'author', 'id'));
-        $this->assertEquals([['Person', 'author', 'id']], $query->getJoins());
+        $this->assertEquals([['Person', 'author', 'id', 'JOIN']], $query->getJoins());
     }
 
     public function testWith()


### PR DESCRIPTION
**Description**
Pulsar doesn't support any join types outside of `JOIN`. It's useful to be able to query using other join types like `LEFT JOIN`. This change adds the ability to pass join types directly to JAQB.

**Testing**
The `QueryTest` and `DatabaseDriverTest` classes has been updated according to the change.